### PR TITLE
Highlight lint output

### DIFF
--- a/bootstrap/command/lint
+++ b/bootstrap/command/lint
@@ -16,13 +16,15 @@
 
 . $BACARDI_PATH/bootstrap/common/path_info.sh
 
+format_diff="$(bootstrap_command_path)/format --diff"
+
 function need_to_format() {
-  result=$($(bootstrap_command_path)/format --diff)
+  result=$($format_diff)
   if [ "$result" = "no modified files to format" ] \
       || [ "$result" = "clang-format did not modify any files" ]; then
     return 1
   else
-    echo "$result"
+    $format_diff
     return 0
   fi
 }


### PR DESCRIPTION
When executing the lint command, the output is not readable because
all highlight tags are removed, so made it out to change the script
order a little.

ISSUE=#164