### PR TITLE
Add a logic to process `enum`

### DIFF
--- a/generator/new_parser/definition_info.ts
+++ b/generator/new_parser/definition_info.ts
@@ -65,10 +65,16 @@ export interface DictionaryMemberInfo {
   readonly default: TypeValue;
 }
 
+export interface EnumInfo {
+  readonly type: 'enum';
+  readonly name: string;
+  readonly values: TypeValue[];
+}
+
 export interface TypeValue {
   readonly type: string;
   readonly value: string;
 }
 
 export type InterfaceMemberInfo = OperationMemberInfo;
-export type DefinitionInfo = InterfaceInfo | DictionaryInfo;
+export type DefinitionInfo = InterfaceInfo | DictionaryInfo | EnumInfo;

--- a/generator/new_parser/definition_info_map.ts
+++ b/generator/new_parser/definition_info_map.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-    DefinitionInfo, DictionaryInfo, InterfaceInfo
+    DefinitionInfo, DictionaryInfo, EnumInfo, InterfaceInfo
   } from 'generator/new_parser/definition_info';
 
 interface DefinitionInfoStore {
@@ -64,6 +64,18 @@ function updateDictionaryInfo(info: DictionaryInfo): void {
   storedInfo.members = storedInfo.members.concat(info.members);
 }
 
+function updateEnumInfo(info: EnumInfo): void {
+  const storedInfo: DefinitionInfo = store[info.name];
+
+  if (storedInfo === undefined) {
+    store[info.name] = info;
+
+    return;
+  }
+
+  throw new SyntaxError('IDL defintions are duplicated');
+}
+
 function updateDefinitionInfo(info: DefinitionInfo): void {
   switch (info.type) {
   case 'interface':
@@ -71,6 +83,9 @@ function updateDefinitionInfo(info: DefinitionInfo): void {
     break;
   case 'dictionary':
     updateDictionaryInfo(info as DictionaryInfo);
+    break;
+  case 'enum':
+    updateEnumInfo(info as EnumInfo);
     break;
   default:
   }


### PR DESCRIPTION
After this patch, `DefinitionInfoMap` can process `enum`. Other
definitions will be ignored for now.

ISSUE=#207