### PR TITLE
Add test for string member of dictionaries

### DIFF
--- a/template/dictionary_types.njk
+++ b/template/dictionary_types.njk
@@ -1,3 +1,11 @@
+{%- macro printType(type) -%}
+{%- if type == 'string' -%}
+  std::{{type}}
+{%- else -%}
+  {{type}}
+{%- endif -%}
+{%- endmacro -%}
+
 /**
  * Copyright (c) 2017 The Bacardi Authors.
  *
@@ -17,21 +25,19 @@
 #ifndef GEN_DICTIONARY_{{name | snakecase | upper}}_H_
 #define GEN_DICTIONARY_{{name | snakecase | upper}}_H_
 
-using namespace::std;
-
 class {{name}} {
 public:
 {% for member in members %}
-  {{member.type}} {{member.name}}() const {
+  {{printType(member.type)}} {{member.name}}() const {
     return {{member.name}}_;
   }
-  void set{{member.name | pascalcase}}({{member.type}} {{member.name}}) {
+  void set{{member.name | pascalcase}}({{printType(member.type)}} {{member.name}}) {
     {{member.name}}_ = {{member.name}};
   }
 {% endfor %}
 private:
 {% for member in members %}
-  {{member.type}} {{member.name}}_;
+  {{printType(member.type)}} {{member.name}}_;
 {% endfor %}
 };
 

--- a/template/dictionary_types.njk
+++ b/template/dictionary_types.njk
@@ -17,6 +17,8 @@
 #ifndef GEN_DICTIONARY_{{name | snakecase | upper}}_H_
 #define GEN_DICTIONARY_{{name | snakecase | upper}}_H_
 
+using namespace::std;
+
 class {{name}} {
 public:
 {% for member in members %}

--- a/test/interface_dictionary.test.ts
+++ b/test/interface_dictionary.test.ts
@@ -23,8 +23,8 @@ test(
     async () => {
       let test_interface = new bacardi.TestInterface();
 
-      var testDict = {a: 10};
+      var testDict = {a: 10, b: "test"};
       expect(test_interface.doubleMethodTestDictionaryArg(testDict)).toBe(10);
       expect(bacardi.TestInterface.getLastCallInfo())
-          .toBe('DoubleMethodTestDictionaryArg()');
+          .toBe('DoubleMethodTestDictionaryArg() : test');
     });

--- a/test/test_interface.cc
+++ b/test/test_interface.cc
@@ -136,6 +136,6 @@ void TestInterface::SetStaticDoubleNumber(double number) {
 }
 
 double TestInterface::DoubleMethodTestDictionaryArg(TestDict testDict) {
-  last_call_info_ = "DoubleMethodTestDictionaryArg()";
+  last_call_info_ = "DoubleMethodTestDictionaryArg() : " + testDict.b();
   return testDict.a();
 }

--- a/test/test_interface.idl
+++ b/test/test_interface.idl
@@ -64,4 +64,5 @@ enum TestEnum {
 
 dictionary TestDict {
   double a;
+  string b;
 };


### PR DESCRIPTION
When dictionary has string member, "std::" was missed in front of string
keyword. So, it makes build error.

ISSUE=#169