### PR TITLE
Add custom lint rule about import

### DIFF
--- a/lint_rules/noImportOtherModulesRule.ts
+++ b/lint_rules/noImportOtherModulesRule.ts
@@ -13,17 +13,17 @@ export class Rule extends Lint.Rules.AbstractRule {
 class NoImportOtherModulesWalker extends Lint.RuleWalker {
   public visitImportDeclaration(node: ts.ImportDeclaration) {
     // create a failure at the current position
-  	const PROJECT_STRING = "bacardi";
-	  const sourcePath = (node.parent as ts.SourceFile).fileName;
-	  const importPath = (node.moduleSpecifier as any).text as string;
-	  if (importPath.includes('/')) {
-		  let importModuleName = importPath.split('/')[0];
-		  let relativeSourcePath = sourcePath.split(PROJECT_STRING)[1];
-		  let sourceModuleName = relativeSourcePath.split('/')[1];
-		  if (importModuleName != sourceModuleName) {
-		  	this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
-		  }
-	  }
+    const PROJECT_STRING = "bacardi";
+    const sourcePath = (node.parent as ts.SourceFile).fileName;
+    const importPath = (node.moduleSpecifier as any).text as string;
+    if (importPath.includes('/')) {
+      let importModuleName = importPath.split('/')[0];
+      let relativeSourcePath = sourcePath.split(PROJECT_STRING)[1];
+      let sourceModuleName = relativeSourcePath.split('/')[1];
+      if (importModuleName != sourceModuleName) {
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+      }
+    }
 
     // call the base version of this visitor to actually parse this node
     super.visitImportDeclaration(node);

--- a/lint_rules/noImportOtherModulesRule.ts
+++ b/lint_rules/noImportOtherModulesRule.ts
@@ -1,0 +1,31 @@
+import * as ts from "typescript";
+import * as Lint from "tslint";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "should not import sub modules in other folder";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NoImportOtherModulesWalker(sourceFile, this.getOptions()));
+    }
+}
+
+// The walker takes care of all the work.
+class NoImportOtherModulesWalker extends Lint.RuleWalker {
+    public visitImportDeclaration(node: ts.ImportDeclaration) {
+        // create a failure at the current position
+	const PROJECT_STRING = "bacardi";
+	const sourcePath = (node.parent as ts.SourceFile).fileName;
+	const importPath = (node.moduleSpecifier as any).text as string;
+	if (importPath.includes('/')) {
+		let importModuleName = importPath.split('/')[0];
+		let relativeSourcePath = sourcePath.split(PROJECT_STRING)[1];
+		let sourceModuleName = relativeSourcePath.split('/')[1];
+		if (importModuleName != sourceModuleName) {
+			this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+		}
+	}
+
+        // call the base version of this visitor to actually parse this node
+        super.visitImportDeclaration(node);
+    }
+}

--- a/lint_rules/noImportOtherModulesRule.ts
+++ b/lint_rules/noImportOtherModulesRule.ts
@@ -2,30 +2,30 @@ import * as ts from "typescript";
 import * as Lint from "tslint";
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "should not import sub modules in other folder";
+  public static FAILURE_STRING = "should not import sub modules in other folder";
 
-    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        return this.applyWithWalker(new NoImportOtherModulesWalker(sourceFile, this.getOptions()));
-    }
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(new NoImportOtherModulesWalker(sourceFile, this.getOptions()));
+  }
 }
 
 // The walker takes care of all the work.
 class NoImportOtherModulesWalker extends Lint.RuleWalker {
-    public visitImportDeclaration(node: ts.ImportDeclaration) {
-        // create a failure at the current position
-	const PROJECT_STRING = "bacardi";
-	const sourcePath = (node.parent as ts.SourceFile).fileName;
-	const importPath = (node.moduleSpecifier as any).text as string;
-	if (importPath.includes('/')) {
-		let importModuleName = importPath.split('/')[0];
-		let relativeSourcePath = sourcePath.split(PROJECT_STRING)[1];
-		let sourceModuleName = relativeSourcePath.split('/')[1];
-		if (importModuleName != sourceModuleName) {
-			this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
-		}
-	}
+  public visitImportDeclaration(node: ts.ImportDeclaration) {
+    // create a failure at the current position
+  	const PROJECT_STRING = "bacardi";
+	  const sourcePath = (node.parent as ts.SourceFile).fileName;
+	  const importPath = (node.moduleSpecifier as any).text as string;
+	  if (importPath.includes('/')) {
+		  let importModuleName = importPath.split('/')[0];
+		  let relativeSourcePath = sourcePath.split(PROJECT_STRING)[1];
+		  let sourceModuleName = relativeSourcePath.split('/')[1];
+		  if (importModuleName != sourceModuleName) {
+		  	this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+		  }
+	  }
 
-        // call the base version of this visitor to actually parse this node
-        super.visitImportDeclaration(node);
-    }
+    // call the base version of this visitor to actually parse this node
+    super.visitImportDeclaration(node);
+  }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,7 @@
     "max-line-length": [true, 80],
     "no-banned-terms": false,
     "no-implicit-dependencies": false,
+    "no-import-other-modules": true,
     "no-reserved-keywords": false,
     "no-stateless-class": false,
     "no-submodule-imports": false,
@@ -24,5 +25,6 @@
       "parameter",
       "variable-declaration"
     ]
-  }
+  },
+  "rulesDirectory": ["./lint_rules/"]
 }


### PR DESCRIPTION
I wanted to pretend package-private feature in this project.
In order to do that, adding tslint custom rule prevents the case when
ts file tries to import other modules in another folder except index.ts.

ISSUE=#231